### PR TITLE
Shifted away from POC of switch statement and to separate HTTP mapping

### DIFF
--- a/server/grpc/errors.go
+++ b/server/grpc/errors.go
@@ -1,0 +1,21 @@
+package grpc
+
+import (
+	"google.golang.org/grpc/codes"
+)
+
+var hToGrpcCodes = map[int32]codes.Code{
+	400: codes.InvalidArgument,
+	401: codes.Unauthenticated,
+	403: codes.Unauthenticated,
+	404: codes.NotFound,
+}
+
+func convertHTTPCode(c int32) codes.Code {
+	code, ok := hToGrpcCodes[c]
+	if !ok {
+		return codes.Internal
+	}
+
+	return code
+}

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -364,14 +364,7 @@ func (g *grpcServer) processRequest(t transport.ServerTransport, stream *transpo
 				statusCode = err.code
 				statusDesc = err.desc
 			} else if err, ok := appErr.(*microErrors.Error); ok {
-				switch err.Code {
-				case 404:
-					statusCode = codes.NotFound
-				case 401:
-					statusCode = codes.Unauthenticated
-				default:
-					statusCode = codes.Internal
-				}
+				statusCode = convertHTTPCode(err.Code)
 				statusDesc = err.Detail
 			} else {
 				statusCode = convertCode(appErr)


### PR DESCRIPTION
Rather than run with a switch statement bound to the micro error, it felt a bit more extensible to
pull out a simple convert method in the spirit of convertCode. 

Improvement thoughts: 
there are issues around the 1:1 mapping of the http codes, ie:
[http-grpc-status-mapping](https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md).

There is also a large discrepancy in ready to go available codes within go-micro/errors. Would be
good to add to that for more specific usage (along the lines of what grpc already offers).

For clarity's sake, should probably pull convertCode into the errors file.